### PR TITLE
Fixed bug when calling reverse and forward geocoding - update

### DIFF
--- a/lib/src/service/geocode_client.dart
+++ b/lib/src/service/geocode_client.dart
@@ -27,7 +27,15 @@ class GeocodeclientImpl implements GeocodeClient {
     String urlParams =
         "/$latitude,$longitude" + (apiKey != '' ? '&auth=' + apiKey : '');
 
-    final Uri uri = Uri.https(url, urlParams, {"geoit": "json"});
+    Map<String, dynamic> queryParams = {
+      'geoit': 'json',
+    };
+
+    if (apiKey != '') {
+      queryParams.addAll({'auth': apiKey});
+    }
+
+    final Uri uri = Uri.https(url, urlParams, queryParams);
 
     return http.get(uri).then((response) {
       ResponseError err = ResponseError.fromJson(json.decode(response.body));
@@ -42,10 +50,17 @@ class GeocodeclientImpl implements GeocodeClient {
 
   @override
   Future<Coordinates> forwardGeocoding(String address, String apiKey) {
-    String urlParams = "/${address.replaceAll(' ', '+')}" +
-        (apiKey != '' ? '&auth=' + apiKey : '');
+    String urlParams = "/${address.replaceAll(' ', '+')}";
 
-    final Uri uri = Uri.https(url, urlParams, {"geoit": "json"});
+    Map<String, dynamic> queryParams = {
+      'geoit': 'json',
+    };
+
+    if (apiKey != '') {
+      queryParams.addAll({'auth': apiKey});
+    }
+
+    final Uri uri = Uri.https(url, urlParams, queryParams);
 
     return http.get(uri).then((response) {
       ResponseError err = ResponseError.fromJson(json.decode(response.body));

--- a/test/geoode_test.dart
+++ b/test/geoode_test.dart
@@ -3,7 +3,8 @@ import 'package:test/test.dart';
 import '../lib/geocode.dart';
 
 void main() {
-  GeoCode geoCode = GeoCode();
+  // THIS IS AN PUBLIC API KEY AND JUST FOR TESTING PURPOSES
+  GeoCode geoCode = GeoCode(apiKey:'254964637064265319091x56863');
 
   group('test geocode', () {
     test('it should return a valid city when requested valid lat & lng',


### PR DESCRIPTION
Fixed a bug caused by get request in reverse/forward geocoding function with incorrect parameter string. Also added a public geocode api key for the unit tests, since geocode blocked unauthenticated user requests.