### PR TITLE
Prevent adding apiKey twice and add custom user-agent header

### DIFF
--- a/lib/src/service/geocode_client.dart
+++ b/lib/src/service/geocode_client.dart
@@ -25,7 +25,7 @@ class GeocodeclientImpl implements GeocodeClient {
   Future<Address> reverseGeocoding(
       double latitude, double longitude, String apiKey) {
     String urlParams =
-        "/$latitude,$longitude" + (apiKey != '' ? '&auth=' + apiKey : '');
+        "/$latitude,$longitude";
 
     Map<String, String> queryParams = {
       'geoit': 'json',

--- a/lib/src/service/geocode_client.dart
+++ b/lib/src/service/geocode_client.dart
@@ -37,7 +37,7 @@ class GeocodeclientImpl implements GeocodeClient {
 
     final Uri uri = Uri.https(url, urlParams, queryParams);
 
-    return http.get(uri).then((response) {
+    return http.get(uri, headers: {'User-Agent': 'geocode (dart:io)'}).then((response) {
       ResponseError err = ResponseError.fromJson(json.decode(response.body));
 
       if (err.code != null) {
@@ -62,7 +62,7 @@ class GeocodeclientImpl implements GeocodeClient {
 
     final Uri uri = Uri.https(url, urlParams, queryParams);
 
-    return http.get(uri).then((response) {
+    return http.get(uri, headers: {'User-Agent': 'geocode (dart:io)'}).then((response) {
       ResponseError err = ResponseError.fromJson(json.decode(response.body));
 
       if (err.code != null) {


### PR DESCRIPTION
In version 1.0.2 I still see malformed URL like this

`https://geocode.xyz/59.6586467,10.9956267&auth=123...?geoit=json&auth=123...`

The apiKey is included twice and the url has an `&` before the query parameters begin. This patch removes the `&` and apiKey from the url, as the API key also get added to the query params where it belongs.

After applying the patch I see url's like this

`https://geocode.xyz/59.6488783,11.0190283?geoit=json&auth=123...`
